### PR TITLE
Updating the chart and the instructions to set the vk name

### DIFF
--- a/vk-burst-demo/README.md
+++ b/vk-burst-demo/README.md
@@ -86,19 +86,10 @@ $ chmod u+x assignFQDNtoIP.sh
 $ ./assignFQDNtoIP.sh -g <myResourceGroup> -d <appName> -i <IP Address>
 ```
 
-Edit the values.yaml file and replace all `<host name>` with the FQDN name in pervious step.
+Edit the values.yaml file and replace all `<host name>` with the FQDN name in previous step.
 ```
 $ vim ./charts/fr-demo/values.yaml 
 ```
-
-Start at the top of the aci-demos directory and deploy the Facial Recognition application that consists of a frontend, a backend, and a set of image recognizers.
-
-```
-$ helm install charts/fr-demo --name demo
-```
-
-Checkout the UI that's generated in the output and see the pictures start to get processed
-The rate will be super slow because we have a 1 node AKS cluster running 1 worker pod.
 
 Deploy the ACI connector :
 Replace `<myResourceGroupmy>`, `<myK8sCluster>` with yours in previous steps and run following command
@@ -113,13 +104,19 @@ The connector has been deployed and with a `kubectl get nodes` you can see that 
 kubectl get node
 ```
 
-Check the connector node name matches the name in the file ir-aci-deployment.yaml
+Edit the values.yaml file and replace the '<vkname>' with the ACI connector name in previous step.
+```
+$ vim ./charts/fr-demo/values.yaml 
+```
+
+Start at the top of the aci-demos directory and deploy the Facial Recognition application that consists of a frontend, a backend, and a set of image recognizers.
 
 ```
-$ grep nodeName ./charts/fr-demo/templates/ir-aci-deployment.yaml     
+$ helm install charts/fr-demo --name demo
 ```
 
-If it doesnt match, change the name in the ir-aci-deployment.yaml to reflect the current connector node name.
+Checkout the UI that's generated in the output and see the pictures start to get processed
+The rate will be super slow because we have a 1 node AKS cluster running 1 worker pod.
 
 Now scale up the image recognizer to 10 using the following command
 

--- a/vk-burst-demo/README.md
+++ b/vk-burst-demo/README.md
@@ -107,7 +107,21 @@ Replace `<myResourceGroupmy>`, `<myK8sCluster>` with yours in previous steps and
 az aks install-connector --resource-group <myResourceGroup> --name <myK8sCluster> --connector-name myaciconnector
 ```
 
-The connector has been deployed and with a `kubectl get nodes` you can see that the ACI Connector is a new node in your cluster. Now scale up the image recognizer to 10 using the following command
+The connector has been deployed and with a `kubectl get nodes` you can see that the ACI Connector is a new node in your cluster.
+
+```
+kubectl get node
+```
+
+Check the connector node name matches the name in the file ir-aci-deployment.yaml
+
+```
+$ grep nodeName ./charts/fr-demo/templates/ir-aci-deployment.yaml
+```
+
+If it doesnt match, change the name in the ir-aci-deployment.yaml to reflect the current connector node name.
+
+Now scale up the image recognizer to 10 using the following command
 
 ```
 $ kubectl scale deploy demo-fr-ir-aci --replicas 10

--- a/vk-burst-demo/README.md
+++ b/vk-burst-demo/README.md
@@ -104,7 +104,7 @@ The connector has been deployed and with a `kubectl get nodes` you can see that 
 kubectl get node
 ```
 
-Edit the values.yaml file and replace the '<vkname>' with the ACI connector name in previous step.
+Edit the values.yaml file and replace the `<vkname>` with the ACI connector name got in the previous step.
 ```
 $ vim ./charts/fr-demo/values.yaml 
 ```

--- a/vk-burst-demo/README.md
+++ b/vk-burst-demo/README.md
@@ -117,6 +117,7 @@ Check the connector node name matches the name in the file ir-aci-deployment.yam
 
 ```
 $ grep nodeName ./charts/fr-demo/templates/ir-aci-deployment.yaml
+       nodeName: virtual-kubelet-myaciconnector-linux-westeurope
 ```
 
 If it doesnt match, change the name in the ir-aci-deployment.yaml to reflect the current connector node name.

--- a/vk-burst-demo/README.md
+++ b/vk-burst-demo/README.md
@@ -116,8 +116,7 @@ kubectl get node
 Check the connector node name matches the name in the file ir-aci-deployment.yaml
 
 ```
-$ grep nodeName ./charts/fr-demo/templates/ir-aci-deployment.yaml
-       nodeName: virtual-kubelet-myaciconnector-linux-westeurope
+$ grep nodeName ./charts/fr-demo/templates/ir-aci-deployment.yaml     
 ```
 
 If it doesnt match, change the name in the ir-aci-deployment.yaml to reflect the current connector node name.

--- a/vk-burst-demo/charts/fr-demo/templates/ir-aci-deployment.yaml
+++ b/vk-burst-demo/charts/fr-demo/templates/ir-aci-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       - name: pic-volume
         emptyDir: {}
       dnsPolicy: ClusterFirst
-      nodeName: virtual-kubelet-myaciconnector-linux 
+      nodeName: "{{ .Values.connector.name }}"
       tolerations:
       - key: azure.com/aci
         effect: NoSchedule

--- a/vk-burst-demo/charts/fr-demo/templates/ir-aci-deployment.yaml
+++ b/vk-burst-demo/charts/fr-demo/templates/ir-aci-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       - name: pic-volume
         emptyDir: {}
       dnsPolicy: ClusterFirst
-      nodeName: "{{ .Values.connector.name }}"
+      nodeName: "{{ .Values.connector.vkname }}"
       tolerations:
       - key: azure.com/aci
         effect: NoSchedule

--- a/vk-burst-demo/charts/fr-demo/values.yaml
+++ b/vk-burst-demo/charts/fr-demo/values.yaml
@@ -96,3 +96,5 @@ backend:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
+connector:
+  name: "virtual-kubelet-myaciconnector-linux-westeurope"

--- a/vk-burst-demo/charts/fr-demo/values.yaml
+++ b/vk-burst-demo/charts/fr-demo/values.yaml
@@ -97,4 +97,4 @@ backend:
     #  cpu: 100m
     #  memory: 128Mi
 connector:
-  name: "virtual-kubelet-myaciconnector-linux-westeurope"
+  vkname: "virtual-kubelet-myaciconnector-linux-westeurope"


### PR DESCRIPTION
With the latest az aks install-connector command, the node name in k8s includes the localtion on Azure, for example:
virtual-kubelet-myaciconnector-linux-westeurope

So, we need to update the ir-aci-deployment.yaml in order to get the ACI replicas going to the connector.
