### PR TITLE
Update NodeSelector and Tolerations

### DIFF
--- a/vk-burst-demo/charts/fr-demo/templates/ir-aci-deployment.yaml
+++ b/vk-burst-demo/charts/fr-demo/templates/ir-aci-deployment.yaml
@@ -41,7 +41,13 @@ spec:
       - name: pic-volume
         emptyDir: {}
       dnsPolicy: ClusterFirst
-      nodeName: virtual-kubelet-myaciconnector-linux 
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        kubernetes.io/role: agent
+        type: virtual-kubelet
       tolerations:
-      - key: azure.com/aci
+      - key: virtual-kubelet.io/provider
+        operator: Equal
+        value: azure
         effect: NoSchedule
+


### PR DESCRIPTION
When I ran through the demo, it did not schedule the pods on ACI.  For one, the node name had changed (now `virtual-kubelet-myaciconnector-linux-eastus`). 

Looking at the latest documentation, the new way to specify ACI is via the change in the PR.  See: https://docs.microsoft.com/en-us/azure/aks/virtual-kubelet#run-linux-container